### PR TITLE
Use TTL cache for stations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "the-septa-times"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "A CLI application for the SEPTA API"
 homepage = "https://github.com/dotzenith/TheSeptaTimes.rs"

--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ tst train 9374
 tst stations
 ```
 
-#### Refresh the cache for station names:
+#### Manually refresh the cache for station names:
+> tst automatically refreshes the cache every week, this command is usually not needed
 ```sh
 tst refresh
 ```
@@ -114,7 +115,7 @@ tst refresh
 ---
 
 ### ❖ What's New? 
-0.6.0 - Allow stations to be addressed by their common names
+0.6.1 - Use TTL caching for station names
 
 ---
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,10 @@ fn main() {
                 .arg(arg!(number: [TRAIN_NUM])),
         )
         .subcommand(Command::new("stations").about("Get all valid station names"))
-        .subcommand(Command::new("refresh").about("Refresh the cache for station names"))
+        .subcommand(
+            Command::new("refresh")
+                .about("Manually refresh the cache for station names (note: tst automatically refreshes every week)"),
+        )
         .get_matches();
 
     match matches.subcommand() {


### PR DESCRIPTION
The manual refresh sub-command is nice-to-have, but the cache should likely update itself every week.