### PR TITLE
Cleanup the CLI a little

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.0/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.1/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@v4
         with:
@@ -216,8 +216,8 @@ jobs:
       - plan
       - build-local-artifacts
       - build-global-artifacts
-    # Only run if we're "publishing", and only if local and global didn't fail (skipped is fine)
-    if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
+    # Only run if we're "publishing", and only if plan, local and global didn't fail (skipped is fine)
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "ubuntu-22.04"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,7 +4,7 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.30.0"
+cargo-dist-version = "0.30.1"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ enum Commands {
         to: String,
 
         /// Number of results to return
-        #[arg(long, default_value = "5")]
+        #[arg(long, short, default_value = "5")]
         count: u8,
     },
 
@@ -42,7 +42,7 @@ enum Commands {
         station: String,
 
         /// Number of results to return
-        #[arg(long, default_value = "5")]
+        #[arg(long, short, default_value = "5")]
         count: u8,
     },
 
@@ -76,9 +76,11 @@ enum ExtraCommands {
         dest: String,
 
         /// Direction (inbound or outbound)
+        #[arg(long, short, default_value = "inbound")]
         direction: ScheduleDirection,
 
         /// Mode (weekend or weekday)
+        #[arg(long, short, default_value = "weekday")]
         mode: ScheduleMode,
     },
 
@@ -91,7 +93,7 @@ enum ExtraCommands {
         line: String,
 
         /// Direction (inbound or outbound)
-        #[arg(long, default_value = "inbound")]
+        #[arg(long, short, default_value = "inbound")]
         direction: ScheduleDirection,
     },
 }


### PR DESCRIPTION
The `schedule` command takes entirely too much work to use. This PR just makes some of the args optional with a reasonable default. 

Also offer a short flag for the flags already being used.